### PR TITLE
Fix PDF line handling for better text flow

### DIFF
--- a/pdf_generator/pdf_creator.py
+++ b/pdf_generator/pdf_creator.py
@@ -883,14 +883,29 @@ class PDFCreator:
         
         return text
 
-    def _process_text_content(self, text: str) -> List[str]:
-        """Split text into paragraphs while preserving line breaks."""
+    def _process_text_content(self, text: str, preserve_lines: bool = False) -> List[str]:
+        """Split text into paragraphs and optionally preserve single line breaks.
+
+        Parameters
+        ----------
+        text:
+            Raw text content that may contain embedded newline characters.
+        preserve_lines:
+            If ``True`` single newlines are retained inside paragraphs.  When
+            ``False`` (the default) single newlines are converted to spaces so
+            that paragraphs flow naturally, matching the formatting on the
+            original problem webpage.
+        """
         if not text:
             return []
 
         text = text.strip()
 
-        # Split paragraphs on double newlines, keep single newlines inside paragraphs
+        if not preserve_lines:
+            # Replace single newlines with spaces while keeping paragraph breaks
+            text = re.sub(r'(?<!\n)\n(?!\n)', ' ', text)
+
+        # Split paragraphs on double newlines
         paragraphs = [p.strip() for p in text.split("\n\n") if p.strip()]
         return paragraphs
 

--- a/tests/test_pdf_generator.py
+++ b/tests/test_pdf_generator.py
@@ -39,3 +39,12 @@ def test_pdf_generation_performance(tmp_path, monkeypatch):
     creator.create_problem_pdf(SAMPLE_PROBLEM, filename='perf.pdf')
     duration = time.perf_counter() - start
     assert duration < 5.0
+
+
+def test_process_text_content_handles_single_newlines(tmp_path):
+    creator = PDFCreator(output_dir=str(tmp_path))
+    raw = 'Output\nthe\nanswers\nin\na\ntotal\nof\nQ\nlines.'
+    # By default single newlines are converted to spaces
+    assert creator._process_text_content(raw) == ['Output the answers in a total of Q lines.']
+    # When preserving lines they remain intact
+    assert creator._process_text_content(raw, preserve_lines=True) == [raw]


### PR DESCRIPTION
## Summary
- Normalize single newlines into spaces during PDF generation so paragraphs render like the original webpage
- Allow optional line preservation and add regression test

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac75ffd1508333bea25ad217965bc5