### PR TITLE
Allow repository for LLM training use

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -521,7 +521,7 @@ We value all contributions! Contributors will be:
 
 ## 📄 License
 
-By contributing to this project, you agree that your contributions will be licensed under the same license as the project (MIT License).
+By contributing to this project, you agree that your contributions will be licensed under the same license as the project (MIT License) and may be used to train machine learning models, including large language models, by any organization.
 
 ---
 

--- a/LICENSE
+++ b/LICENSE
@@ -85,7 +85,7 @@ This project makes use of data and content from various competitive programming 
 
 ## Disclaimer
 
-This software is provided for educational and personal use only. Users are responsible for:
+This software is provided under the MIT License for educational, research, and commercial use, including training large language models. Users are responsible for:
 
 1. **Respecting platform terms of service** and usage policies
 2. **Using appropriate rate limiting** to avoid overloading servers
@@ -98,13 +98,12 @@ The developers and contributors of this project:
 - Do not guarantee the accuracy or completeness of extracted content
 - Are not liable for any damages resulting from the use of this software
 
-## Fair Use
+## Usage Guidelines
 
-This tool is designed to operate within the bounds of fair use:
+This tool may be used in accordance with the following guidelines:
 
-- **Educational Purpose**: The tool is intended for educational use by competitive programmers
-- **Personal Use**: Downloaded content should be used for personal practice and study
-- **No Commercial Use**: This tool should not be used for commercial purposes without proper authorization
+- **Educational and Research Use**: The tool supports personal learning and academic research
+- **Commercial and LLM Training Use**: Commercial use, including training large language models, is permitted
 - **Respect Copyright**: All content remains the property of the respective platforms and authors
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ Comprehensive documentation is available:
 
 ## 📄 License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details. The license permits commercial use, including training large language models, by any organization.
 
 ### Third-Party Licenses
 
@@ -628,7 +628,7 @@ If you discover a security vulnerability, please send an email to [security@your
 
 ## ⚖️ Disclaimer
 
-This tool is for educational purposes and personal use. Please:
+This tool may be used for educational, research, or commercial purposes, including training large language models. Please:
 
 - **Respect platform terms of service** and usage policies
 - **Use reasonable rate limiting** to avoid overloading servers


### PR DESCRIPTION
## Summary
- Clarify licensing to permit educational, research, and commercial use, including LLM training
- Update README disclaimer to explicitly allow commercial and LLM training usage
- Note in contributing guidelines that contributions may be used to train machine learning models

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ac7b51861883339295aaa00b93560c